### PR TITLE
style: moved imgs to center, reduced padding and margin

### DIFF
--- a/src/layouts/team-profile.njk
+++ b/src/layouts/team-profile.njk
@@ -36,7 +36,11 @@ Coded by www.creative-tim.com
   <link id="pagestyle" href="/static/assets/css/soft-design-system-pro.css?v=1.0.1" rel="stylesheet" />
   <!-- CSS Just for demo purpose, don't include it in your project -->
   <!-- <link href="/static/assets/demo/demo.css" rel="stylesheet" /> -->
-
+<style>
+.overlay-image {
+    z-index: 10;
+}
+</style>
 </head>
 
 <body class="{{ body_class }}">
@@ -52,20 +56,29 @@ Coded by www.creative-tim.com
               <div class="container">
                 <div class="row">
 
-                  <div class="card card-body blur text-md-left text-center px-sm-5 shadow-lg mt-sm-5 py-sm-5">
-                    <div class="card card-body blur text-md-left text-center px-sm-5 shadow-lg mt-sm-5 py-sm-5">
+                  <div class="position-relative">
                       {% if image %}
-                      <img src="{{ image }}" alt="Photo of {{ title }}" class="img-fluid rounded-circle shadow mb-4"
-                        style="max-width: 200px;">
+                          <img src="{{ image }}"
+                              alt="Photo of {{ title }}"
+                              class="position-absolute top: -10 start-50 translate-middle-x rounded shadow overlay-image"
+                              style="max-width: 200px; top: -80px;">
                       {% endif %}
-                      <h2 class="text-dark text-gradient text-primary mb-0">
-                        {{ title }}
-                      </h2>
-                      <h4 class="text-secondary mb-4">{{ role }}</h4>
-                      <div class="text-dark" style="text-align: left; justify-content: flex-start;">
-                        {{ content | safe }}
+                  <div class="card card-body blur text-md-left text-center px-sm-3 shadow-lg mt-sm-5 py-sm-0">
+                        
+
+                      <div class="card card-body blur text-md-left text-center mb-sm-3 px-sm-5 shadow-lg mt-sm-3 py-sm-0">
+                          <h2 class="text-dark text-gradient text-primary mb-0 mt-7">
+                              {{ title }}
+                          </h2>
+                          <h4 class="text-secondary mb-4">{{ role }}</h4>
+                            <div class="text-dark" style="text-align: left; justify-content: flex-start;">
+                                {{ content | safe }}
+                            </div>
                       </div>
-                    </div>
+
+                      </div>
+                  </div>
+                </div>
                   </div>
                 </div>
 


### PR DESCRIPTION
Moved the images on individual teams pages to the center, changed padding and margin to be smaller so the cards looked overlapped 